### PR TITLE
make.sh: update idbloader.img generation

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -20,7 +20,11 @@ BOARD ?= rk3399-vaaman
 ${BOARD}:
 	@mkdir -p debian/build/$@
 
-	./make.sh ${BOARD}
+	@if [ "${BOARD}" = "rk3588-axon" ]; then \
+		./make.sh ${BOARD} --spl; \
+	else \
+		./make.sh ${BOARD}; \
+	fi
 
 	@cp uboot.img debian/build/${BOARD}/u-boot.img
 	@cp idbloader.img debian/build/${BOARD}/idbloader.img

--- a/make.sh
+++ b/make.sh
@@ -765,6 +765,7 @@ function pack_images()
 	if [ "${ARG_RAW_COMPILE}" != "y" ]; then
 		if [ "${PLAT_TYPE}" == "FIT" ]; then
 			pack_fit_image ${ARG_LIST_FIT}
+			pack_idblock
 		elif [ "${PLAT_TYPE}" == "DECOMP" ]; then
 			${SCRIPT_DECOMP} ${ARG_LIST_FIT} --chip ${RKCHIP_LABEL}
 		else


### PR DESCRIPTION
This change updates the `idbloader.img` by rebuilding it, which now includes the`rk3588_ddr_lp4_2112MHz_lp5_2736MHz_v1.14.bin` instead of `u-boot-tpl.bin`. 
Previously, the boot process would hang at the TPL stage.