### PR TITLE
cmd: pxe: Increase FDT overlay buffer from 8KB to 32KB.

### DIFF
--- a/cmd/pxe.c
+++ b/cmd/pxe.c
@@ -672,7 +672,7 @@ static int label_boot_fdtoverlay(cmd_tbl_t *cmdtp, struct pxe_label *label)
 		}
 
 		/* Resize main fdt */
-		fdt_shrink_to_minimum(working_fdt, 8192);
+		fdt_shrink_to_minimum(working_fdt, 32768);
 
 		blob = map_sysmem(fdtoverlay_addr, 0);
 		err = fdt_check_header(blob);


### PR DESCRIPTION
- Increase the extra space parameter in fdt_shrink_to_minimum() from 8192 to 32768 bytes when applying device tree overlays. This provides additional headroom for overlay operations and prevents FDT_ERR_NOSPACE errors that can occur when applying larger overlays.

- The previous 8KB buffer was insufficient for certain overlay scenarios, leading to failures during the overlay application process. The expanded 32KB buffer ensures adequate space for overlay nodes and properties.