### PR TITLE
rockchip: gate fbbase console output behind framebuffer config

### DIFF
--- a/cmd/pxe.c
+++ b/cmd/pxe.c
@@ -1668,9 +1668,8 @@ static void handle_pxe_menu(cmd_tbl_t *cmdtp, struct pxe_menu *cfg)
 	if (!m)
 		return;
 
-#ifdef CONFIG_DRM_ROCKCHIP
+#ifdef CONFIG_DRM_ROCKCHIP_VIDEO_FRAMEBUFFER
 	run_command("rockchip_show_fbbase", 0);
-
 #endif
 
 	puts(ANSI_CLEAR_CONSOLE);

--- a/common/autoboot.c
+++ b/common/autoboot.c
@@ -272,7 +272,10 @@ static int abortboot(int bootdelay)
 #endif
 
 	if(abort){
+#ifdef CONFIG_DRM_ROCKCHIP_VIDEO_FRAMEBUFFER
 		run_command("rockchip_show_fbbase", 0);
+#endif
+
 #ifdef CONFIG_CMD_BOOTMENU
 		if (had_ctrlq())
 			run_command("bootmenu 10", 0);
@@ -372,7 +375,11 @@ void autoboot_command(const char *s)
 #if defined(CONFIG_AUTOBOOT_KEYED) && !defined(CONFIG_AUTOBOOT_KEYED_CTRLC)
 		disable_ctrlc(prev);	/* restore Control C checking */
 #endif
+
+#ifdef CONFIG_DRM_ROCKCHIP_VIDEO_FRAMEBUFFER
 		run_command("rockchip_show_fbbase", 0);
+#endif
+
 #ifdef CONFIG_CMD_BOOTMENU
 		if (had_ctrlq())
 			run_command("bootmenu 10", 0);


### PR DESCRIPTION
rockchip_show_fbbase is used to show the U-Boot console, menus and logs on HDMI. The calls were guarded by CONFIG_DRM_ROCKCHIP, which is too broad: disabling it would disable the whole Rockchip DRM driver instead of only the framebuffer console output.

Guard these calls with CONFIG_DRM_ROCKCHIP_VIDEO_FRAMEBUFFER so HDMI console output can be disabled independently while keeping DRM enabled.