### PR TITLE
debian: rule: Add Axon CM EVB1 board for U-Boot compliance

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -20,7 +20,7 @@ BOARD ?= rk3399-vaaman
 ${BOARD}:
 	@mkdir -p debian/build/$@
 
-	@if [ "${BOARD}" = "rk3588-axon" ]; then \
+	@if [[ "${BOARD}" = "rk3588-axon" || "${BOARD}" = "rk3588-axon-cm-evb1" ]]; then \
 		./make.sh ${BOARD} --spl; \
 	else \
 		./make.sh ${BOARD}; \


### PR DESCRIPTION
Update debian/rules to include the Axon CM EVB1 board, ensuring proper building and compliance with U-Boot targets.