### PR TITLE
hotkey: fix console-lock bypass for ROCKUSB_DNL/FASTBOOT hotkeys

### DIFF
--- a/arch/arm/mach-rockchip/hotkey.c
+++ b/arch/arm/mach-rockchip/hotkey.c
@@ -38,12 +38,14 @@ bool is_hotkey(enum hotkey_t id)
 		return gd->console_evt == CTRL_B;
 
 #ifndef CONFIG_CONSOLE_DISABLE_CLI
-	if (!console_magic_match) {
-		case HK_ROCKUSB_DNL:
+	case HK_ROCKUSB_DNL:
+		if (!console_magic_match)
 			return gd->console_evt == CTRL_D;
-		case HK_FASTBOOT:
+		break;
+	case HK_FASTBOOT:
+		if (!console_magic_match)
 			return gd->console_evt == CTRL_F;
-	}
+		break;
 #endif
 	default:
 		break;


### PR DESCRIPTION
## Problem

`is_hotkey()` in `arch/arm/mach-rockchip/hotkey.c` is supposed to gate the
`HK_ROCKUSB_DNL` and `HK_FASTBOOT` hotkeys behind `console_magic_match`, so
that a production-locked board (eMMC magic bytes present) cannot be forced
into rockusb-download or fastboot mode via a Ctrl+D/Ctrl+F keypress on the
serial console at boot.

The guard was implemented as:

```c
if (!console_magic_match) {
    case HK_ROCKUSB_DNL:
        return gd->console_evt == CTRL_D;
    case HK_FASTBOOT:
        return gd->console_evt == CTRL_F;
}
```

`switch` jumps directly to the matching `case` label regardless of the
enclosing `if`, so the `console_magic_match` check is never evaluated on
this path. The lock has no effect on these two hotkeys: pressing Ctrl+D or
Ctrl+F drops the board into download/fastboot mode whether or not the
console is supposed to be locked.

Reachable on the default build (`CONFIG_ROCKCHIP_HOTKEY=y`,
`CONFIG_CONSOLE_DISABLE_CLI=n`, unchanged in all vicharak defconfigs) via
`board_late_init()` → `setup_download_mode()` → `is_hotkey()`.

## Fix

Move the `case` labels back to the top level of the `switch` and push the
`console_magic_match` check into each case body instead — matching the
existing, correct pattern already used for this flag in `cli.c`,
`console.c`, and `menu.c`.

## Test

Added `rktest hotkey_lock` in `test/rockchip/test-download.c`: sets
`console_magic_match = true`, drives `gd->console_evt` through the
Ctrl+D/Ctrl+F codes, and asserts `is_hotkey()` returns `false` for both.
Fails on current `master`, passes with this fix.