### PR TITLE
common: fix console magic and bootkey build dependencies

### DIFF
--- a/board/vicharak/common/vicharak_common.c
+++ b/board/vicharak/common/vicharak_common.c
@@ -9,8 +9,6 @@
 #include <blk.h>
 #include <console.h>
 
-bool console_magic_match;
-
 /**
  * is_mmc_magic_match - Check if the MMC magic sequence matches
  *

--- a/common/autoboot.c
+++ b/common/autoboot.c
@@ -30,6 +30,7 @@ DECLARE_GLOBAL_DATA_PTR;
 /* Stored value of bootdelay, used by autoboot_command() */
 static int stored_bootdelay;
 
+#ifdef CONFIG_BOOTKEY
 static void rkflash_enter_loader_mode(void)
 {
 #if defined(CONFIG_ROCKCHIP_BOOT_MODE_REG)
@@ -37,6 +38,7 @@ static void rkflash_enter_loader_mode(void)
 #endif
 	do_reset(NULL, 0, 0, NULL);
 }
+#endif
 
 #if defined(CONFIG_AUTOBOOT_KEYED)
 #if defined(CONFIG_AUTOBOOT_STOP_STR_SHA256)

--- a/common/console.c
+++ b/common/console.c
@@ -26,6 +26,7 @@
 #endif
 
 DECLARE_GLOBAL_DATA_PTR;
+bool console_magic_match;
 
 static int on_console(const char *name, const char *value, enum env_op op,
 	int flags)


### PR DESCRIPTION
console_magic_match is referenced by generic console, menu and CLI code, but was defined only by the Vicharak board library. Move its definition to common console code so non-Vicharak targets can link successfully.

Guard rkflash_enter_loader_mode() with CONFIG_BOOTKEY since its callers are only built when boot-key support is enabled.