### PR TITLE
This PR adds Android boot support to Axon Linux U-Boot.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+u-boot-vicharak (1.1.15) stable; urgency=medium
+
+  * Add Ctrl+B shortcut to enter Rockchip loader mode during autoboot.
+  * Enable Android boot command `boot_android` support on Axon linux.
+  * Try Android boot first on all supported boot media.
+  * Increase the U-Boot FIT slot to support the larger Android-enabled image.
+  * Fix prompt handling for kernel menu
+
+ -- Ajit Singh <ajeetsinghchahar2@gmail.com>  Fri, 07 Aug 2026 10:30:00 +0530
+
 u-boot-vicharak (1.1.14) stable; urgency=medium
 
   * Increase FDT overlay buffer from 8KB to 32KB, if the overlays size gets

--- a/include/config_distro_bootcmd.h
+++ b/include/config_distro_bootcmd.h
@@ -26,11 +26,19 @@
  * message that includes some other pre-processor symbols in the text.
  */
 
+#ifdef CONFIG_CMD_BOOT_ANDROID
+#define BOOTENV_ANDROID_BLKDEV(devtypel) \
+	"boot_android " #devtypel " ${devnum} || "
+#else
+#define BOOTENV_ANDROID_BLKDEV(devtypel)
+#endif
+
 #define BOOTENV_SHARED_BLKDEV_BODY(devtypel) \
-		"if " #devtypel " dev ${devnum}; then " \
-			"setenv devtype " #devtypel "; " \
-			"run scan_dev_for_boot_part; " \
-		"fi\0"
+	"if " #devtypel " dev ${devnum}; then " \
+		"setenv devtype " #devtypel "; " \
+		BOOTENV_ANDROID_BLKDEV(devtypel) \
+		"run scan_dev_for_boot_part; " \
+	"fi\0"
 
 #define BOOTENV_SHARED_BLKDEV(devtypel) \
 	#devtypel "_boot=" \


### PR DESCRIPTION
Attempts Android boot first on supported boot media, falling back to the existing distro boot flow.

Since this may add a ~1–2 second delay to every boot, I'm not sure whether this behavior should be merged into the master branch. Leaving this as a PR for now for review and discussion.